### PR TITLE
Add option: allow users to send email as themselves w/ System outgoing

### DIFF
--- a/modules/EmailMan/controller.php
+++ b/modules/EmailMan/controller.php
@@ -98,6 +98,7 @@ class EmailManController extends SugarController
         $configurator->config['email_enable_confirm_opt_in'] = isset($_REQUEST['email_enable_confirm_opt_in']) ? $_REQUEST['email_enable_confirm_opt_in'] : SugarEmailAddress::COI_STAT_DISABLED;
         $configurator->config['email_enable_auto_send_opt_in'] = (isset($_REQUEST['email_enable_auto_send_opt_in'])) ? true : false;
         $configurator->config['email_confirm_opt_in_email_template_id'] = isset($_REQUEST['email_template_id_opt_in']) ? $_REQUEST['email_template_id_opt_in'] : $configurator->config['aop']['confirm_opt_in_template_id'];
+        $configurator->config['email_allow_send_as_user']  = ($_REQUEST['mail_allowusersend'] == '1') ? true : false;
         ///////////////////////////////////////////////////////////////////////////////
         ////	SECURITY
         $security = array();

--- a/modules/EmailMan/language/en_us.lang.php
+++ b/modules/EmailMan/language/en_us.lang.php
@@ -137,4 +137,6 @@ $mod_strings = array(
     'LBL_FROM_ADDRESS_HELP' => 'When enabled, the assigning user\\\'s name and email address will be included in the From field of the email. This feature might not work with SMTP servers that do not allow sending from a different email account than the server account.',
     'LBL_HELP' => 'Help' /*for 508 compliance fix*/,
     'LBL_OUTBOUND_EMAIL_ACCOUNT_VIEW' => 'View Outbound Email Accounts',
+    'LBL_ALLOW_SEND_AS_USER' => 'User May Send As Self:',
+    'LBL_ALLOW_SEND_AS_USER_DESC' => 'When enabled, all users can send email using the outgoing mail server, using their own primary email address as the \\\'From:\\\' address. This feature might not work with SMTP servers that do not allow sending from a different email account than the server account.',
 );

--- a/modules/EmailMan/tpls/config.tpl
+++ b/modules/EmailMan/tpls/config.tpl
@@ -196,8 +196,14 @@ function change_state(radiobutton) {
 												<input type='hidden' id="notify_allow_default_outbound_hidden_input" name='notify_allow_default_outbound' value='0'>
 												<input id="notify_allow_default_outbound" name='notify_allow_default_outbound' value="2" tabindex='1' class="checkbox" type="checkbox" {$notify_allow_default_outbound_on}>
 											</td>
-											<td width="20%">&nbsp;</td>
-											<td width="30%">&nbsp;</td>
+											<td width="20%">
+                                                                                                {$MOD.LBL_ALLOW_SEND_AS_USER}&nbsp;
+                                                                                                <img border="0" class="inlineHelpTip" onclick="return SUGAR.util.showHelpTips(this,'{$MOD.LBL_ALLOW_SEND_AS_USER_DESC}','','','dialogHelpPopup')" src="index.php?entryPoint=getImage&themeName={$THEME}&imageName=helpInline.gif">
+											</td>
+											<td width="30%">
+                                                                                                <input type='hidden' id="mail_allowusersend_hidden_input" name='mail_allowusersend' value='0'>
+                                                                                                <input id='mail_allowusersend' name='mail_allowusersend' type="checkbox" class="checkbox" value="1" tabindex='1' {$mail_allow_user_send}>
+											</td>
 										</tr>
 									</table>
 								</div>

--- a/modules/EmailMan/views/view.config.php
+++ b/modules/EmailMan/views/view.config.php
@@ -169,6 +169,12 @@ class ViewConfig extends SugarView
             LoggerManager::getLogger()->error('EmailMan view display error: mail send type is not set for focus');
         }
         
+        $mailAllowUserSend = null;
+        if (isset($sugar_config['email_allow_send_as_user'])) {
+            $mailAllowUserSend = $sugar_config['email_allow_send_as_user'];
+        } else {
+            LoggerManager::getLogger()->error('EmailMan view display error: mail allow user send is not set for focus');
+        }
         
         
         $this->ss->assign("mail_smtptype", $mailSmtpType);
@@ -178,6 +184,7 @@ class ViewConfig extends SugarView
         $this->ss->assign("mail_smtpauth_req", ($mailSmtpAuthReq) ? "checked='checked'" : "");
         $this->ss->assign("mail_haspass", empty($mailSmtpPass)?0:1);
         $this->ss->assign("MAIL_SSL_OPTIONS", get_select_options_with_id($app_list_strings['email_settings_for_ssl'], $mailSmtpSsl));
+        $this->ss->assign("mail_allow_user_send", ($mailAllowUserSend) ? "checked='checked'" : "");
 
         //Assign the current users email for the test send dialogue.
         $this->ss->assign("CURRENT_USER_EMAIL", $current_user->email1);

--- a/modules/Emails/EmailsController.php
+++ b/modules/Emails/EmailsController.php
@@ -367,6 +367,7 @@ class EmailsController extends SugarController
     public function action_GetFromFields()
     {
         global $current_user;
+        global $sugar_config;
         $email = new Email();
         $email->email2init();
         $ie = new InboundEmail();
@@ -447,6 +448,24 @@ class EmailsController extends SugarController
 
                 $data[] = $dataAddress;
             }
+        }
+
+        if ($sugar_config['email_allow_send_as_user']) {
+            $data[] = array(
+                'type' => 'personal',
+                'id' => $current_user->id,
+                'attributes' => array(
+                    'from' => $current_user->email1,
+                    'name' => $current_user->full_name,
+                ),
+                'prepend' => $prependSignature,
+                'isPersonalEmailAccount' => true,
+                'isGroupEmailAccount' => false,
+                'emailSignatures' => array(
+                    'html' => utf8_encode(html_entity_decode($defaultEmailSignature['signature_html'])),
+                    'plain' => $defaultEmailSignature['signature'],
+                ),
+            );
         }
 
         $oe = new OutboundEmail();


### PR DESCRIPTION
With this option enabled, users will be able to send email out
of SuiteCRM with their name and email address, but sending though
the system outgoing email server. Their email address and name
will be populated in the "From" dropdown.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->